### PR TITLE
:bug: Fix broken search for hyphenated names

### DIFF
--- a/scripts/populate-search-fields.js
+++ b/scripts/populate-search-fields.js
@@ -1,9 +1,8 @@
 /* eslint-disable */
 /* Since mongo does not support ES6 we can not lint with our current eslint config */
 
-
 String.prototype.removePunctuation = function () {
-    return this.replace(/[^\w\s]/g,'');
+    return this.replace(/[.,]/g,'');
 };
 
 String.prototype.removeStopWords = function () {


### PR DESCRIPTION
Limit punctuation removed in order to allow hyphenated name searching to work (e.g. Yule-Smith). It is also part of the solution needed to ensure searches for names which include apostrophes work.

May need to reconsider if any other punctuation beyond '.' and ',' needs to be removed from the search terms but I think this is a good starting point.